### PR TITLE
Added Installation and Makefile

### DIFF
--- a/Formula/todo.rb
+++ b/Formula/todo.rb
@@ -1,0 +1,16 @@
+class Todo < Formula
+  desc "A simple CLI todo application written in Go"
+  homepage "https://github.com/AmanTahiliani/todo"
+  version "0.1.0"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", bin/"todo", "./cmd/todo"
+  end
+
+  test do
+    system "#{bin}/todo", "--help"
+  end
+end

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+BINARY_NAME=todo
+INSTALL_PATH=/usr/local/bin
+
+.PHONY: build
+build:
+	go build -o $(BINARY_NAME) ./cmd/todo
+
+.PHONY: install
+install: build
+	mkdir -p $(INSTALL_PATH)
+	cp $(BINARY_NAME) $(INSTALL_PATH)/$(BINARY_NAME)
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(INSTALL_PATH)/$(BINARY_NAME)
+
+.PHONY: clean
+clean:
+	rm -f $(BINARY_NAME)
+
+.PHONY: test
+test:
+	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Go Todo CLI App
+# Todo CLI
 
-A simple command-line Todo application written in Go. Todos are stored in a SQLite database.
+A powerful command-line todo application written in Go. Manage your tasks efficiently with a simple, intuitive interface. All data is automatically stored in a SQLite database in your home directory.
 
 ## Features
 
@@ -8,77 +8,87 @@ A simple command-line Todo application written in Go. Todos are stored in a SQLi
 - List all todos, grouped by incomplete and completed
 - Mark todos as completed
 - Remove todos by ID
-- Data is persisted in SQLite database
-- User-friendly command-line interface with action commands
+- Automatic SQLite database management
+- User-friendly command-line interface with intuitive commands
+- Data stored securely in user's home directory
 
-## Dependencies
+## Installation
 
-- Go 1.x
-- github.com/mattn/go-sqlite3
+### Using Go
+
+```bash
+go install github.com/AmanTahiliani/todo/cmd/todo@latest
+```
+
+### Using Make
+
+```bash
+git clone https://github.com/AmanTahiliani/todo.git
+cd todo
+make install
+```
+
+### Using Homebrew (macOS)
+
+```bash
+brew tap AmanTahiliani/todo
+brew install todo
+```
 
 ## Usage
 
-Build the app:
-
-```sh
-go build -o todo
+### Add a new todo
+```bash
+todo add -t "Meeting" -d "Team standup at 10AM"
 ```
 
-### Command Structure
-
-The app uses a command-based interface where the action comes first, followed by flags:
-
-```sh
-./todo [action] [flags]
+### List all todos
+```bash
+todo list
 ```
 
-Available actions:
-- `add` - Add a new todo item
-- `remove` - Remove a todo item
-- `complete` - Mark a todo item as completed
-- `list` - List all todo items
-
-### Flags
-
-- `-t, --title` - Title for the todo (required for add)
-- `-d, --description` - Description for the todo (required for add)
-- `-i, --id` - ID of the todo (required for remove and complete)
-- `-h, --help` - Display help information
-
-### Examples
-
-Add a new todo:
-```sh
-./todo add -t "Buy milk" -d "Get 2 liters of milk"
+### Mark a todo as completed
+```bash
+todo complete -i 1
 ```
 
-List all todos:
-```sh
-./todo list
+### Remove a todo
+```bash
+todo remove -i 1
 ```
 
-Complete a todo:
-```sh
-./todo complete -i 1
+### Get help
+```bash
+todo --help
 ```
 
-Remove a todo:
-```sh
-./todo remove -i 2
+## Data Storage
+
+Todos are automatically stored in a SQLite database located at `~/.todo/todos.db`. The application handles all database operations transparently, so you don't need to worry about database management.
+
+## Development
+
+### Prerequisites
+
+- Go 1.21 or later
+- Make (optional, for easier building)
+
+### Building from source
+
+```bash
+make build
 ```
 
-Display help:
-```sh
-./todo -h
+### Running tests
+
+```bash
+make test
 ```
 
-## Next Improvements
+## License
 
-- Use a CLI library like [cobra](https://github.com/spf13/cobra) for better UX
-- Add edit and search features
-- Add unit tests
-- Improve error handling
-- Add binary release for different platforms and make it available through Homebrew, Winget and Apt
-- Add due dates and priority levels for todos
-- Implement categories/tags for better organization
-- Add data export/import functionality
+MIT License
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module github.com/AmanTahiliani/todo
 
-go 1.24.0
+go 1.21.4
 
-require github.com/mattn/go-sqlite3 v1.14.28
+require (
+	github.com/mattn/go-sqlite3 v1.14.28
+	github.com/spf13/cobra v1.9.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This pull request introduces a new Go-based CLI tool called `todo` for managing tasks. It includes the formula for Homebrew installation, a `Makefile` for building and installing the binary, updates to the `README.md` with detailed instructions, and dependency updates in `go.mod`. Below are the key changes grouped by theme:

### New Formula for Homebrew
* Added a Homebrew formula in `Formula/todo.rb` to enable easy installation of the `todo` CLI via Homebrew. The formula builds the binary using Go and includes a basic test to verify installation.

### Build and Installation Enhancements
* Introduced a `Makefile` with targets for building, installing, uninstalling, cleaning, and testing the `todo` CLI. This simplifies the development and deployment process.

### Documentation Improvements
* Updated `README.md` with clearer installation instructions (via Go, Make, and Homebrew), usage examples, and development guidelines. Added sections on data storage, prerequisites, and contributing.

### Dependency Updates
* Updated `go.mod` to include new dependencies: `cobra` for enhanced CLI functionality and `pflag` for flag parsing. Downgraded the Go version requirement from 1.24.0 to 1.21.4 for compatibility.